### PR TITLE
Fixes for rust warnings: unused vars, unused mut, extra parens

### DIFF
--- a/src/expander.rs
+++ b/src/expander.rs
@@ -51,7 +51,7 @@ pub trait Expander: Sized {
             let (sub_sql, sub_values) = match c {
                 Sql::Literal(t) => (t.to_string(), vec![]),
                 Sql::Binding(b) => self.bind_values(b.name.to_string(), i),
-                Sql::Composition((ss, aliases)) => self.expand_statement(&ss, i, true),
+                Sql::Composition((ss, _aliases)) => self.expand_statement(&ss, i, true),
                 Sql::Ending(e) => {
                     if child {
                         ("".to_string(), vec![])
@@ -160,7 +160,7 @@ pub trait Expander: Sized {
         let mut out = SqlComposition::default();
 
         // columns in this case would mean an expand on each side of the union literal
-        let columns = composition.column_list().unwrap();
+        let _columns = composition.column_list().unwrap();
 
         let mut i = 0usize;
 
@@ -208,7 +208,7 @@ pub trait Expander: Sized {
 
     fn mock_expand(
         &self,
-        stmt: &SqlComposition,
+        _stmt: &SqlComposition,
         mock_values: &Vec<BTreeMap<String, Self::Value>>,
         offset: usize,
     ) -> (String, Vec<Self::Value>) {
@@ -225,7 +225,7 @@ pub trait Expander: Sized {
 
         let mut expected_columns: Option<u8> = None;
 
-        if (mock_values.is_empty()) {
+        if mock_values.is_empty() {
             panic!("mock_values cannot be empty");
         }
         else {

--- a/src/expander/direct.rs
+++ b/src/expander/direct.rs
@@ -58,11 +58,11 @@ impl<'a> Expander for DirectExpander<'a> {
         (self.bind_var_tag(offset, name), vec![])
     }
 
-    fn get_values(&self, name: String) -> Option<&Vec<Self::Value>> {
+    fn get_values(&self, _name: String) -> Option<&Vec<Self::Value>> {
         None
     }
 
-    fn insert_value(&mut self, name: String, values: Vec<Self::Value>) -> () {
+    fn insert_value(&mut self, _name: String, _values: Vec<Self::Value>) -> () {
         //self.values.insert(name, values);
     }
 
@@ -121,7 +121,7 @@ mod tests {
             .insert("time_created".into(), vec![&person.time_created]);
         expander.values.insert("data".into(), vec![&person.data]);
 
-        let (bound_sql, bindings) = expander.expand(&insert_stmt);
+        let (bound_sql, _bindings) = expander.expand(&insert_stmt);
 
         let now_value = now.with_timezone(&Utc).format("%Y-%m-%dT%H:%M:%S%.f");
 
@@ -136,7 +136,7 @@ mod tests {
 
         assert_eq!(remaining, b"", "nothing remaining");
 
-        let (bound_sql, bindings) = expander.expand(&select_stmt);
+        let (bound_sql, _bindings) = expander.expand(&select_stmt);
 
         let expected_bound_sql = format!("SELECT id, name, time_created, data FROM person WHERE name = '{}' AND time_created = '{}' AND name = '{}' AND time_created = '{}';", &person.name, now_value, &person.name, now_value);
 

--- a/src/expander/mysql.rs
+++ b/src/expander/mysql.rs
@@ -189,7 +189,7 @@ mod tests {
     }
 
     fn parse(input: &str) -> SqlComposition {
-        let (remaining, stmt) = parse_template(input.as_bytes(), None).unwrap();
+        let (_remaining, stmt) = parse_template(input.as_bytes(), None).unwrap();
 
         stmt
     }
@@ -230,7 +230,7 @@ mod tests {
         let (bound_sql, bindings) = expander.expand(&stmt);
         expander.root_mock_values = mock_values;
 
-        let (mut mock_bound_sql, mock_bindings) = expander.expand(&stmt);
+        let (mock_bound_sql, mock_bindings) = expander.expand(&stmt);
 
         let mut prep_stmt = pool.prepare(&bound_sql).unwrap();
 
@@ -246,7 +246,7 @@ mod tests {
             values.push(get_row_values(row.unwrap()));
         }
 
-        let mut mock_prep_stmt = pool.prepare(&bound_sql).unwrap();
+        let _mock_prep_stmt = pool.prepare(&bound_sql).unwrap();
 
         let mock_rebindings = mock_bindings.iter().fold(Vec::new(), |mut acc, x| {
             acc.push(*x);
@@ -413,7 +413,7 @@ mod tests {
     fn test_multi_value_bind() {
         let pool = setup_db();
 
-        let (remaining, stmt) = parse_template(b"SELECT * FROM (:expand(src/tests/values/double-include.tql)) AS main WHERE col_1 in (:bind(col_1_values)) AND col_3 IN (:bind(col_3_values));", None).unwrap();
+        let (_remaining, stmt) = parse_template(b"SELECT * FROM (:expand(src/tests/values/double-include.tql)) AS main WHERE col_1 in (:bind(col_1_values)) AND col_3 IN (:bind(col_3_values));", None).unwrap();
 
         let expected_bound_sql = "SELECT * FROM (SELECT ? AS col_1, ? AS col_2, ? AS col_3, ? AS col_4 UNION ALL SELECT ? AS col_1, ? AS col_2, ? AS col_3, ? AS col_4 UNION ALL SELECT ? AS col_1, ? AS col_2, ? AS col_3, ? AS col_4) AS main WHERE col_1 in (?, ?) AND col_3 IN (?, ?);";
 
@@ -463,7 +463,7 @@ mod tests {
     fn test_count_command() {
         let pool = setup_db();
 
-        let (remaining, stmt) =
+        let (_remaining, stmt) =
             parse_template(b":count(src/tests/values/double-include.tql);", None).unwrap();
 
         println!("made it through parse");
@@ -513,7 +513,7 @@ mod tests {
     fn test_union_command() {
         let pool = setup_db();
 
-        let (remaining, stmt) = parse_template(b":union(src/tests/values/double-include.tql, src/tests/values/include.tql, src/tests/values/double-include.tql);", None).unwrap();
+        let (_remaining, stmt) = parse_template(b":union(src/tests/values/double-include.tql, src/tests/values/include.tql, src/tests/values/double-include.tql);", None).unwrap();
 
         println!("made it through parse");
         let expected_bound_sql = "SELECT ? AS col_1, ? AS col_2, ? AS col_3, ? AS col_4 UNION ALL SELECT ? AS col_1, ? AS col_2, ? AS col_3, ? AS col_4 UNION ALL SELECT ? AS col_1, ? AS col_2, ? AS col_3, ? AS col_4 UNION SELECT ? AS col_1, ? AS col_2, ? AS col_3, ? AS col_4 UNION ALL SELECT ? AS col_1, ? AS col_2, ? AS col_3, ? AS col_4 UNION SELECT ? AS col_1, ? AS col_2, ? AS col_3, ? AS col_4 UNION ALL SELECT ? AS col_1, ? AS col_2, ? AS col_3, ? AS col_4 UNION ALL SELECT ? AS col_1, ? AS col_2, ? AS col_3, ? AS col_4";
@@ -567,7 +567,7 @@ mod tests {
     fn test_include_mock_multi_value_bind() {
         let pool = setup_db();
 
-        let (remaining, stmt) = parse_template(b"SELECT * FROM (:expand(src/tests/values/double-include.tql)) AS main WHERE col_1 in (:bind(col_1_values)) AND col_3 IN (:bind(col_3_values));", None).unwrap();
+        let (_remaining, stmt) = parse_template(b"SELECT * FROM (:expand(src/tests/values/double-include.tql)) AS main WHERE col_1 in (:bind(col_1_values)) AND col_3 IN (:bind(col_3_values));", None).unwrap();
 
         let expected_bound_sql = "SELECT * FROM (SELECT ? AS col_1, ? AS col_2, ? AS col_3, ? AS col_4 UNION ALL SELECT ? AS col_1, ? AS col_2, ? AS col_3, ? AS col_4) AS main WHERE col_1 in (?, ?) AND col_3 IN (?, ?);";
 
@@ -597,7 +597,7 @@ mod tests {
         > = HashMap::new();
 
         {
-            let mut path_entry = mock_values
+            let path_entry = mock_values
                 .entry(PathBuf::from("src/tests/values/include.tql"))
                 .or_insert(Vec::new());
 
@@ -634,7 +634,7 @@ mod tests {
     fn test_mock_double_include_multi_value_bind() {
         let pool = setup_db();
 
-        let (remaining, stmt) = parse_template(b"SELECT * FROM (:expand(src/tests/values/double-include.tql)) AS main WHERE col_1 in (:bind(col_1_values)) AND col_3 IN (:bind(col_3_values));", None).unwrap();
+        let (_remaining, stmt) = parse_template(b"SELECT * FROM (:expand(src/tests/values/double-include.tql)) AS main WHERE col_1 in (:bind(col_1_values)) AND col_3 IN (:bind(col_3_values));", None).unwrap();
 
         let expected_bound_sql = "SELECT * FROM (SELECT ? AS col_1, ? AS col_2, ? AS col_3, ? AS col_4 UNION ALL SELECT ? AS col_1, ? AS col_2, ? AS col_3, ? AS col_4 UNION ALL SELECT ? AS col_1, ? AS col_2, ? AS col_3, ? AS col_4) AS main WHERE col_1 in (?, ?) AND col_3 IN (?, ?);";
 
@@ -665,7 +665,7 @@ mod tests {
         > = HashMap::new();
 
         {
-            let mut path_entry = mock_values
+            let path_entry = mock_values
                 .entry(PathBuf::from("src/tests/values/double-include.tql"))
                 .or_insert(Vec::new());
 

--- a/src/expander/postgres.rs
+++ b/src/expander/postgres.rs
@@ -43,7 +43,7 @@ impl<'a> Expander for PostgresExpander<'a> {
         let mut sql = String::new();
         let mut new_values = vec![];
 
-        let i = offset;
+        let _i = offset;
 
         match self.values.get(&name) {
             Some(v) => {
@@ -233,7 +233,7 @@ mod tests {
 
         mock_bound_sql.push(';');
 
-        let mut prep_stmt = conn.prepare(&bound_sql).unwrap();
+        let prep_stmt = conn.prepare(&bound_sql).unwrap();
 
         let mut values: Vec<Vec<String>> = vec![];
         let mut mock_values: Vec<Vec<String>> = vec![];
@@ -247,7 +247,7 @@ mod tests {
             values.push(get_row_values(row));
         }
 
-        let mut mock_prep_stmt = conn.prepare(&mock_bound_sql).unwrap();
+        let mock_prep_stmt = conn.prepare(&mock_bound_sql).unwrap();
 
         let mock_rebindings = mock_bindings.iter().fold(Vec::new(), |mut acc, x| {
             acc.push(*x);
@@ -297,7 +297,7 @@ mod tests {
 
         println!("bound_sql: {}", bound_sql);
 
-        let mut prep_stmt = conn.prepare(&bound_sql).unwrap();
+        let prep_stmt = conn.prepare(&bound_sql).unwrap();
 
         let mut values: Vec<Vec<String>> = vec![];
 
@@ -310,7 +310,7 @@ mod tests {
             values.push(get_row_values(row));
         }
 
-        let mut mock_prep_stmt = conn.prepare(&bound_sql).unwrap();
+        let mock_prep_stmt = conn.prepare(&bound_sql).unwrap();
 
         let mut mock_values: Vec<Vec<String>> = vec![];
 
@@ -368,7 +368,7 @@ mod tests {
 
         mock_bound_sql.push(';');
 
-        let mut prep_stmt = conn.prepare(&bound_sql).unwrap();
+        let prep_stmt = conn.prepare(&bound_sql).unwrap();
 
         let mut values: Vec<Vec<String>> = vec![];
 
@@ -381,7 +381,7 @@ mod tests {
             values.push(get_row_values(row));
         }
 
-        let mut mock_prep_stmt = conn.prepare(&bound_sql).unwrap();
+        let mock_prep_stmt = conn.prepare(&bound_sql).unwrap();
 
         let mut mock_values: Vec<Vec<String>> = vec![];
 
@@ -402,7 +402,7 @@ mod tests {
     fn test_multi_value_bind() {
         let conn = setup_db();
 
-        let (remaining, stmt) = parse_template(b"SELECT col_1, col_2, col_3, col_4 FROM (:expand(src/tests/values/double-include.tql)) AS main WHERE col_1 in (:bind(col_1_values)) AND col_3 IN (:bind(col_3_values));", None).unwrap();
+        let (_remaining, stmt) = parse_template(b"SELECT col_1, col_2, col_3, col_4 FROM (:expand(src/tests/values/double-include.tql)) AS main WHERE col_1 in (:bind(col_1_values)) AND col_3 IN (:bind(col_3_values));", None).unwrap();
 
         let expected_sql = "SELECT col_1, col_2, col_3, col_4 FROM (SELECT $1 AS col_1, $2 AS col_2, $3 AS col_3, $4 AS col_4 UNION ALL SELECT $5 AS col_1, $6 AS col_2, $7 AS col_3, $8 AS col_4 UNION ALL SELECT $9 AS col_1, $10 AS col_2, $11 AS col_3, $12 AS col_4) AS main WHERE col_1 in ($13, $14) AND col_3 IN ($15, $16);";
 
@@ -434,7 +434,7 @@ mod tests {
 
         assert_eq!(bound_sql, expected_sql, "preparable statements match");
 
-        let mut prep_stmt = conn.prepare(&bound_sql).unwrap();
+        let prep_stmt = conn.prepare(&bound_sql).unwrap();
 
         let mut values: Vec<Vec<String>> = vec![];
 
@@ -453,7 +453,7 @@ mod tests {
     fn test_count_command() {
         let conn = setup_db();
 
-        let (remaining, stmt) =
+        let (_remaining, stmt) =
             parse_template(b":count(src/tests/values/double-include.tql);", None).unwrap();
 
         println!("made it through parse");
@@ -480,7 +480,7 @@ mod tests {
 
         assert_eq!(bound_sql, expected_bound_sql, "preparable statements match");
 
-        let mut prep_stmt = conn.prepare(&bound_sql).unwrap();
+        let prep_stmt = conn.prepare(&bound_sql).unwrap();
 
         let mut values: Vec<Vec<Option<i64>>> = vec![];
 
@@ -502,7 +502,7 @@ mod tests {
     fn test_union_command() {
         let conn = setup_db();
 
-        let (remaining, stmt) = parse_template(b":union(src/tests/values/double-include.tql, src/tests/values/include.tql, src/tests/values/double-include.tql);", None).unwrap();
+        let (_remaining, stmt) = parse_template(b":union(src/tests/values/double-include.tql, src/tests/values/include.tql, src/tests/values/double-include.tql);", None).unwrap();
 
         println!("made it through parse");
         let expected_bound_sql = "SELECT $1 AS col_1, $2 AS col_2, $3 AS col_3, $4 AS col_4 UNION ALL SELECT $5 AS col_1, $6 AS col_2, $7 AS col_3, $8 AS col_4 UNION ALL SELECT $9 AS col_1, $10 AS col_2, $11 AS col_3, $12 AS col_4 UNION SELECT $13 AS col_1, $14 AS col_2, $15 AS col_3, $16 AS col_4 UNION ALL SELECT $17 AS col_1, $18 AS col_2, $19 AS col_3, $20 AS col_4 UNION SELECT $21 AS col_1, $22 AS col_2, $23 AS col_3, $24 AS col_4 UNION ALL SELECT $25 AS col_1, $26 AS col_2, $27 AS col_3, $28 AS col_4 UNION ALL SELECT $29 AS col_1, $30 AS col_2, $31 AS col_3, $32 AS col_4";
@@ -528,7 +528,7 @@ mod tests {
 
         assert_eq!(bound_sql, expected_bound_sql, "preparable statements match");
 
-        let mut prep_stmt = conn.prepare(&bound_sql).unwrap();
+        let prep_stmt = conn.prepare(&bound_sql).unwrap();
 
         let mut values: Vec<Vec<String>> = vec![];
 
@@ -556,7 +556,7 @@ mod tests {
     fn test_include_mock_multi_value_bind() {
         let conn = setup_db();
 
-        let (remaining, stmt) = parse_template(b"SELECT * FROM (:expand(src/tests/values/double-include.tql)) AS main WHERE col_1 in (:bind(col_1_values)) AND col_3 IN (:bind(col_3_values));", None).unwrap();
+        let (_remaining, stmt) = parse_template(b"SELECT * FROM (:expand(src/tests/values/double-include.tql)) AS main WHERE col_1 in (:bind(col_1_values)) AND col_3 IN (:bind(col_3_values));", None).unwrap();
 
         let expected_bound_sql = "SELECT * FROM (SELECT $1 AS col_1, $2 AS col_2, $3 AS col_3, $4 AS col_4 UNION ALL SELECT $5 AS col_1, $6 AS col_2, $7 AS col_3, $8 AS col_4) AS main WHERE col_1 in ($9, $10) AND col_3 IN ($11, $12);";
 
@@ -584,7 +584,7 @@ mod tests {
             HashMap::new();
 
         {
-            let mut path_entry = mock_values
+            let path_entry = mock_values
                 .entry(PathBuf::from("src/tests/values/include.tql"))
                 .or_insert(Vec::new());
 
@@ -601,7 +601,7 @@ mod tests {
 
         println!("bound sql: {}", bound_sql);
 
-        let mut prep_stmt = conn.prepare(&bound_sql).unwrap();
+        let prep_stmt = conn.prepare(&bound_sql).unwrap();
 
         let mut values: Vec<Vec<String>> = vec![];
 
@@ -622,7 +622,7 @@ mod tests {
     fn test_mock_double_include_multi_value_bind() {
         let conn = setup_db();
 
-        let (remaining, stmt) = parse_template(b"SELECT * FROM (:expand(src/tests/values/double-include.tql)) AS main WHERE col_1 in (:bind(col_1_values)) AND col_3 IN (:bind(col_3_values));", None).unwrap();
+        let (_remaining, stmt) = parse_template(b"SELECT * FROM (:expand(src/tests/values/double-include.tql)) AS main WHERE col_1 in (:bind(col_1_values)) AND col_3 IN (:bind(col_3_values));", None).unwrap();
 
         let expected_bound_sql = "SELECT * FROM (SELECT $1 AS col_1, $2 AS col_2, $3 AS col_3, $4 AS col_4 UNION ALL SELECT $5 AS col_1, $6 AS col_2, $7 AS col_3, $8 AS col_4 UNION ALL SELECT $9 AS col_1, $10 AS col_2, $11 AS col_3, $12 AS col_4) AS main WHERE col_1 in ($13, $14) AND col_3 IN ($15, $16);";
 
@@ -651,7 +651,7 @@ mod tests {
             HashMap::new();
 
         {
-            let mut path_entry = mock_values
+            let path_entry = mock_values
                 .entry(PathBuf::from("src/tests/values/double-include.tql"))
                 .or_insert(Vec::new());
 
@@ -678,7 +678,7 @@ mod tests {
 
         let (bound_sql, bindings) = expander.expand_statement(&stmt, 1, false);
 
-        let mut prep_stmt = conn.prepare(&bound_sql).unwrap();
+        let prep_stmt = conn.prepare(&bound_sql).unwrap();
 
         let mut values: Vec<Vec<String>> = vec![];
 

--- a/src/expander/rusqlite.rs
+++ b/src/expander/rusqlite.rs
@@ -411,7 +411,7 @@ mod tests {
         mock_values[2].insert("col_4".into(), &"d_value");
 
         let (bound_sql, bindings) = expander.expand(&stmt);
-        let (mut mock_bound_sql, mock_bindings) = expander.mock_expand(&stmt, &mock_values, 0);
+        let (mut mock_bound_sql, _mock_bindings) = expander.mock_expand(&stmt, &mock_values, 0);
 
         mock_bound_sql.push(';');
 
@@ -467,7 +467,7 @@ mod tests {
     fn test_multi_value_bind() {
         let conn = setup_db();
 
-        let (remaining, stmt) = parse_template(b"SELECT col_1, col_2, col_3, col_4 FROM (:expand(src/tests/values/double-include.tql)) AS main WHERE col_1 in (:bind(col_1_values)) AND col_3 IN (:bind(col_3_values));", None).unwrap();
+        let (_remaining, stmt) = parse_template(b"SELECT col_1, col_2, col_3, col_4 FROM (:expand(src/tests/values/double-include.tql)) AS main WHERE col_1 in (:bind(col_1_values)) AND col_3 IN (:bind(col_3_values));", None).unwrap();
 
         let expected_sql = "SELECT col_1, col_2, col_3, col_4 FROM (SELECT ?1 AS col_1, ?2 AS col_2, ?3 AS col_3, ?4 AS col_4 UNION ALL SELECT ?5 AS col_1, ?6 AS col_2, ?7 AS col_3, ?8 AS col_4 UNION ALL SELECT ?9 AS col_1, ?10 AS col_2, ?11 AS col_3, ?12 AS col_4) AS main WHERE col_1 in (?13, ?14) AND col_3 IN (?15, ?16);";
 
@@ -527,7 +527,7 @@ mod tests {
     fn test_count_command() {
         let conn = setup_db();
 
-        let (remaining, stmt) =
+        let (_remaining, stmt) =
             parse_template(b":count(src/tests/values/double-include.tql);", None).unwrap();
 
         println!("made it through parse");
@@ -580,7 +580,7 @@ mod tests {
     fn test_union_command() {
         let conn = setup_db();
 
-        let (remaining, stmt) = parse_template(b":union(src/tests/values/double-include.tql, src/tests/values/include.tql, src/tests/values/double-include.tql);", None).unwrap();
+        let (_remaining, stmt) = parse_template(b":union(src/tests/values/double-include.tql, src/tests/values/include.tql, src/tests/values/double-include.tql);", None).unwrap();
 
         println!("made it through parse");
         let expected_bound_sql = "SELECT ?1 AS col_1, ?2 AS col_2, ?3 AS col_3, ?4 AS col_4 UNION ALL SELECT ?5 AS col_1, ?6 AS col_2, ?7 AS col_3, ?8 AS col_4 UNION ALL SELECT ?9 AS col_1, ?10 AS col_2, ?11 AS col_3, ?12 AS col_4 UNION SELECT ?13 AS col_1, ?14 AS col_2, ?15 AS col_3, ?16 AS col_4 UNION ALL SELECT ?17 AS col_1, ?18 AS col_2, ?19 AS col_3, ?20 AS col_4 UNION SELECT ?21 AS col_1, ?22 AS col_2, ?23 AS col_3, ?24 AS col_4 UNION ALL SELECT ?25 AS col_1, ?26 AS col_2, ?27 AS col_3, ?28 AS col_4 UNION ALL SELECT ?29 AS col_1, ?30 AS col_2, ?31 AS col_3, ?32 AS col_4";
@@ -643,7 +643,7 @@ mod tests {
     fn test_include_mock_multi_value_bind() {
         let conn = setup_db();
 
-        let (remaining, stmt) = parse_template(b"SELECT * FROM (:expand(src/tests/values/double-include.tql)) AS main WHERE col_1 in (:bind(col_1_values)) AND col_3 IN (:bind(col_3_values));", None).unwrap();
+        let (_remaining, stmt) = parse_template(b"SELECT * FROM (:expand(src/tests/values/double-include.tql)) AS main WHERE col_1 in (:bind(col_1_values)) AND col_3 IN (:bind(col_3_values));", None).unwrap();
 
         let expected_bound_sql = "SELECT * FROM (SELECT ?1 AS col_1, ?2 AS col_2, ?3 AS col_3, ?4 AS col_4 UNION ALL SELECT ?5 AS col_1, ?6 AS col_2, ?7 AS col_3, ?8 AS col_4) AS main WHERE col_1 in (?9, ?10) AND col_3 IN (?11, ?12);";
 
@@ -671,7 +671,7 @@ mod tests {
             HashMap::new();
 
         {
-            let mut path_entry = mock_values
+            let path_entry = mock_values
                 .entry(PathBuf::from("src/tests/values/include.tql"))
                 .or_insert(Vec::new());
 
@@ -718,7 +718,7 @@ mod tests {
     fn test_mock_double_include_multi_value_bind() {
         let pool = setup_db();
 
-        let (remaining, stmt) = parse_template(b"SELECT * FROM (:expand(src/tests/values/double-include.tql)) AS main WHERE col_1 in (:bind(col_1_values)) AND col_3 IN (:bind(col_3_values));", None).unwrap();
+        let (_remaining, stmt) = parse_template(b"SELECT * FROM (:expand(src/tests/values/double-include.tql)) AS main WHERE col_1 in (:bind(col_1_values)) AND col_3 IN (:bind(col_3_values));", None).unwrap();
 
         let expected_bound_sql = "SELECT * FROM (SELECT ?1 AS col_1, ?2 AS col_2, ?3 AS col_3, ?4 AS col_4 UNION ALL SELECT ?5 AS col_1, ?6 AS col_2, ?7 AS col_3, ?8 AS col_4 UNION ALL SELECT ?9 AS col_1, ?10 AS col_2, ?11 AS col_3, ?12 AS col_4) AS main WHERE col_1 in (?13, ?14) AND col_3 IN (?15, ?16);";
 
@@ -747,7 +747,7 @@ mod tests {
             HashMap::new();
 
         {
-            let mut path_entry = mock_values
+            let path_entry = mock_values
                 .entry(PathBuf::from("src/tests/values/double-include.tql"))
                 .or_insert(Vec::new());
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -469,7 +469,7 @@ mod tests {
 
         println!("final comp: {}", comp);
 
-        let mut expected = SqlComposition {
+        let expected = SqlComposition {
             command: Some("count".into()),
             path: None,
             of: vec![SqlCompositionAlias {

--- a/src/types.rs
+++ b/src/types.rs
@@ -183,7 +183,7 @@ impl SqlComposition {
     //TODO: error if path already set to Some(...)
     pub fn set_path(&mut self, new: &Path) -> Result<(), ()> {
         match &self.path {
-            Some(current) => Err(()),
+            Some(_current) => Err(()),
             None => {
                 self.path = Some(new.into());
                 Ok(())


### PR DESCRIPTION
* ran 'cargo fix' to auto apply changes
  * prepends `_` to unused variable names.
  * removes `mut` from vars that don't get mutated
  * removes excess parens in `if` conditions.