### PR TITLE
README tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Sql Composer is a SQL pre-processor that helps to manage the intricate relations
 
 The compositions sql-composer build allow you to efficiently interact with your database by providing the following advantages :
 
-* Starts with SQL, which is often the point where an engineer has to start from anyway. The most common case is a DBA suggesting a complex generated query be replaced by a hand crafted that is dramatically more performant.
+* Starts with SQL, which is often the point where an engineer has to start from anyway. The most common case is a DBA suggesting a complex generated query be replaced by a hand crafted query that is dramatically more performant.
 * Prevents a rigid relationship between the database design and the code. As tables change the queries themselves will have to change but will often not require changes to the code itself. 
 * Encourages reuse of complete queries, rather than fragments of text/logic. 
 * Simplifies management of bind placeholders and bind values when preparing/executing statements. 
@@ -22,7 +22,9 @@ The `Composer` only supports two type of macros, one which produces complete sta
 
 This type of macro produces a complete statement composition, and may compose together several other statement compositions.
 
-`:command([all] [distinct] [column1, column2… of] [path, path...])` 
+```rust
+:command([all] [distinct] [column1, column2… of] [path, path...])
+``` 
 
 The most commonly used command is the `compose` command which reads in another composition and expands it in place. The composer handles these calls in a way that nesting calls to commands several layers deep works without an issue.
  NOTE: recursive calls are not currently caught, so care should be taken until this is cleaned up.
@@ -33,11 +35,11 @@ Other commands expand on the concept of calls to `compose` but wrap one or more 
 
 Binding macros have a simpler syntax, since this type of macro doesn’t vary much in it’s behavior by design. Gives the query writer strict control of how a user binds values to the template. 
 
-* :bind(name) - bind a single, not providing a value for the `name` param is an error
-* :bind_opt(name) - (TODO) bind a single value, none are provided then binds as NULL
-* :bind_m - (TODO) bind m (where m >= 1) 
-* :bind_opt_m - (TODO) bind m (where m >= 1), if no values are provided to bind then interpreted as NULL
-* :bind_m_n - (TODO) bind m to n (where m >= 1 and n > m), bind from m to n values without exploding
+* `:bind(name)` - bind a single, not providing a value for the `name` param is an error
+* `:bind_opt(name)` - (TODO) bind a single value, none are provided then binds as NULL
+* `:bind_m` - (TODO) bind m (where m >= 1) 
+* `:bind_opt_m` - (TODO) bind m (where m >= 1), if no values are provided to bind then interpreted as NULL
+* `:bind_m_n` - (TODO) bind m to n (where m >= 1 and n > m), bind from m to n values without exploding
  
 When the `Composer` encounters a bind macro it will create one or more comma separated driver-specific placeholders or a NULL depending on the rules of the particular bind macro. For each placeholder that is added a corresponding value is added to the bind list. Since this is all managed automatcially calls to `SqlComposition.compose()` only need to provide a Hashmap of named values to bind. 
 Project Status


### PR DESCRIPTION
* add code syntax to composition and binding macros.
* fill in missing word.