### PR TITLE
Feature: Add Docker-compose to launch postgres and mysql dbs 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+target/
+Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,39 @@
+version: "3"
+services:
+  postgres:
+    image: "postgres"
+    container_name: "sql_composer_postgres"
+    environment:
+      - POSTGRES_USER=runner
+      - POSTGRES_PASSWORD=
+      - POSTGRES_DB=sql_composer
+    # map to ephemeral port, look up via `docker-compose port sql_composer_postgres 5432`
+    ports:
+      - "5432"
+    # map localhost 5432 to 5432 in container for local access
+    # otherwise use `docker-compose port sql_composer_postgress 5432` to get the port
+    # ports:
+    #   - "5432:5432"
+    # if we need to save data, mount a dir as local volume:
+    # volumes:
+    #  - ./db/postgres-data:/var/lib/postgresql/data
+  mysql:
+    image: "mysql"
+    container_name: "sql_composer_mysql"
+    environment:
+      - MYSQL_USER=runner
+      - MYSQL_PASSWORD=
+      - MYSQL_DATABASE=sql_composer
+      - MYSQL_RANDOM_ROOT_PASSWORD=true
+    ports:
+        - "3306"
+    #   map localhost 3306 to 3306 in container.
+    #   change this if you want to run multiple or have a local db instance
+    #   can look up via `docker-compose port sql_composer_mysql 3306` if we let this
+    #   randomize
+    # ports:
+    #   - "3306:3306"
+    #   map to ephemeral port, look up via `docker-compose port sql_composer_mysql 3306`
+    # if we need to save data, mount a dir as local volume:
+    # volumes:
+    #   - ./db/mysql-data:/var/lib/mysql

--- a/env.database.sh
+++ b/env.database.sh
@@ -1,0 +1,4 @@
+# source this file into your shell to set ENV variables after running docker-compose up:
+#     . ./env.database.sh
+export MYSQL_DATABASE_URL=mysql://runner@$(docker port sql_composer_mysql 3306)/sql_composer
+export PG_DATABASE_URL=postgresql://runner@$(docker port sql_composer_postgres 5432)/sql_composer

--- a/sql-composer/src/composer/mysql.rs
+++ b/sql-composer/src/composer/mysql.rs
@@ -131,6 +131,8 @@ mod tests {
 
     use std::collections::HashMap;
 
+    use std::env;
+
     #[derive(Debug, PartialEq)]
     struct Person {
         id:   i32,
@@ -139,7 +141,9 @@ mod tests {
     }
 
     fn setup_db() -> Pool {
-        let pool = Pool::new("mysql://vagrant:password@localhost:3306/vagrant").unwrap();
+        let pool = Pool::new(
+            env::var("MYSQL_DATABASE_URL").expect("Missing variable MYSQL_DATABASE_URL")
+        ).unwrap();
 
         pool.prep_exec("DROP TABLE IF EXISTS person;", ()).unwrap();
 

--- a/sql-composer/src/composer/postgres.rs
+++ b/sql-composer/src/composer/postgres.rs
@@ -159,6 +159,8 @@ mod tests {
 
     use std::collections::{BTreeMap, HashMap};
 
+    use std::env;
+
     #[derive(Debug, PartialEq)]
     struct Person {
         id:   i32,
@@ -167,7 +169,10 @@ mod tests {
     }
 
     fn setup_db() -> Connection {
-        Connection::connect("postgres://vagrant:vagrant@localhost:5432", TlsMode::None).unwrap()
+        Connection::connect(
+            env::var("PG_DATABASE_URL").expect("Missing variable PG_DATABASE_URL"),
+            TlsMode::None
+        ).unwrap()
     }
 
     #[test]


### PR DESCRIPTION
* Add Docker-compose to launch postgres and mysql dbs 
* includes a cherry-pick of the env-var change from git:eb7f88014252216a42d4a59329d2d5e8cfffb036

docker-compose will download and run containers for mysql and
postgresql.  The internal ports will be forwarded to ephemeral
ports on the host.  The containers will be named
sql_composer_mysql and sql_composer_postgres.  Each will have
an empty database named 'sql_composer' owned by user 'runner'

* use `docker-compose up` to launch databases.  This task will
  stay foregrounded and show the database logs.  ctrl-c to
  shut down the instances
  ```
  docker-compose up             # launch both postgresql and mysql
  docker-compose up mysql       # launch only mysql
  docker-compose up postgresql  # launch only postgresql
  ```

* use docker port to find the ephemeral mapping:
  ```
  docker port sql_composer_mysql 3306      # e.g. 0.0.0.0:32000
  docker port sql_composer_postgresql 5432 # e.g. 0.0.0.0:32001
  ```

* source env.database.sh to set the *DATABASE_URL environment vars
  using the ports from `docker-compose port`
  ```
  . ./env.database.sh
  ```