### PR TITLE
Use configurable port mappings defined in .env

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,12 @@
+# Note: this file is read by both docker-compose and via the dotenv crate,
+# so we may only use the features supported by both.
+
+# local port to forward to the database containers, can
+# be overridden by environment variables.
+MYSQL_DATABASE_PORT=13306
+MYSQL_DATABASE_PASS=postgresisbes
+MYSQL_DATABASE_URL=mysql://runner:${MYSQL_DATABASE_PASS}@0.0.0.0:${MYSQL_DATABASE_PORT}/sql_composer
+
+PG_DATABASE_PORT=15432
+PG_DATABASE_PASS=mysqlhasnoequal
+PG_DATABASE_URL=postgresql://runner:${PG_DATABASE_PASS}@0.0.0.0:${PG_DATABASE_PORT}/sql_composer

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+db/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,35 +5,27 @@ services:
     container_name: "sql_composer_postgres"
     environment:
       - POSTGRES_USER=runner
-      - POSTGRES_PASSWORD=
+      - POSTGRES_PASSWORD=${PG_DATABASE_PASS}
       - POSTGRES_DB=sql_composer
-    # map to ephemeral port, look up via `docker-compose port sql_composer_postgres 5432`
+    # map 5432 to local port $PG_DATABASE_PORT
     ports:
-      - "5432"
-    # map localhost 5432 to 5432 in container for local access
-    # otherwise use `docker-compose port sql_composer_postgress 5432` to get the port
-    # ports:
-    #   - "5432:5432"
-    # if we need to save data, mount a dir as local volume:
-    # volumes:
-    #  - ./db/postgres-data:/var/lib/postgresql/data
+      - "${PG_DATABASE_PORT}:5432"
+    # mount a dir as local volume to control the storage
+    # location.  Without this the container will store
+    # data files elsewhere on the host fs.
+    volumes:
+      - ./db/postgres-data:/var/lib/postgresql/data
   mysql:
     image: "mysql"
+    # restart: "always"
     container_name: "sql_composer_mysql"
     environment:
-      - MYSQL_USER=runner
-      - MYSQL_PASSWORD=
       - MYSQL_DATABASE=sql_composer
+      - MYSQL_USER=runner
+      - MYSQL_PASSWORD=${MYSQL_DATABASE_PASS}
       - MYSQL_RANDOM_ROOT_PASSWORD=true
+    # map 5432 to local port $PG_DATABASE_PORT
     ports:
-        - "3306"
-    #   map localhost 3306 to 3306 in container.
-    #   change this if you want to run multiple or have a local db instance
-    #   can look up via `docker-compose port sql_composer_mysql 3306` if we let this
-    #   randomize
-    # ports:
-    #   - "3306:3306"
-    #   map to ephemeral port, look up via `docker-compose port sql_composer_mysql 3306`
-    # if we need to save data, mount a dir as local volume:
-    # volumes:
-    #   - ./db/mysql-data:/var/lib/mysql
+      - "${MYSQL_DATABASE_PORT}:3306"
+    volumes:
+    - ./db/mysql-data:/var/lib/mysql

--- a/env.database.sh
+++ b/env.database.sh
@@ -1,4 +1,0 @@
-# source this file into your shell to set ENV variables after running docker-compose up:
-#     . ./env.database.sh
-export MYSQL_DATABASE_URL=mysql://runner@$(docker port sql_composer_mysql 3306)/sql_composer
-export PG_DATABASE_URL=postgresql://runner@$(docker port sql_composer_postgres 5432)/sql_composer

--- a/sql-composer/Cargo.toml
+++ b/sql-composer/Cargo.toml
@@ -12,6 +12,7 @@ composer-serde = ["serde", "serde-value"]
 
 [dependencies]
 chrono = "0.4"
+dotenv = "0.15.0"
 error-chain = "0.12.1"
 nom = "4.1.1"
 nom_locate = "0.3.1"

--- a/sql-composer/src/composer/mysql.rs
+++ b/sql-composer/src/composer/mysql.rs
@@ -131,7 +131,9 @@ mod tests {
 
     use std::collections::HashMap;
 
+    use dotenv::dotenv;
     use std::env;
+
 
     #[derive(Debug, PartialEq)]
     struct Person {
@@ -141,6 +143,8 @@ mod tests {
     }
 
     fn setup_db() -> Pool {
+
+        dotenv().ok();
         let pool = Pool::new(
             env::var("MYSQL_DATABASE_URL").expect("Missing variable MYSQL_DATABASE_URL")
         ).unwrap();

--- a/sql-composer/src/composer/postgres.rs
+++ b/sql-composer/src/composer/postgres.rs
@@ -159,6 +159,7 @@ mod tests {
 
     use std::collections::{BTreeMap, HashMap};
 
+    use dotenv::dotenv;
     use std::env;
 
     #[derive(Debug, PartialEq)]
@@ -169,6 +170,8 @@ mod tests {
     }
 
     fn setup_db() -> Connection {
+        dotenv().ok();
+
         Connection::connect(
             env::var("PG_DATABASE_URL").expect("Missing variable PG_DATABASE_URL"),
             TlsMode::None


### PR DESCRIPTION
Switch from ephemeral ports to fixed mappings of host to db containers.  Allow overriding of the ports via environment variables or override in `.env` file.

* add support to read .env file and merge into environment when testing using the `dotenv` crate.
* docker-compose natively supports `.env` file.  
* Use `.env` file to store ports and passwords and allow dev to override via environment variables.
* update docs to match