### PR TITLE
Break dependence between dbd-* features and composer-serde

### DIFF
--- a/sql-composer/src/composer/mysql.rs
+++ b/sql-composer/src/composer/mysql.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, HashMap};
 
 use mysql::{prelude::ToValue, Stmt};
 
+#[cfg(feature = "composer-serde")]
 use mysql::Value;
 
 use super::{Composer, ComposerConfig, ComposerConnection};
@@ -16,6 +17,7 @@ use serde_value::Value as SerdeValueEnum;
 
 use mysql::Pool;
 
+#[cfg(feature = "composer-serde")]
 impl Into<Value> for SerdeValue {
     fn into(self) -> Value {
         match self.0 {

--- a/sql-composer/src/composer/postgres.rs
+++ b/sql-composer/src/composer/postgres.rs
@@ -1,7 +1,9 @@
 use std::collections::{BTreeMap, HashMap};
 
 use postgres::stmt::Statement;
-use postgres::types::{IsNull, ToSql, Type};
+use postgres::types::ToSql;
+#[cfg(feature = "composer-serde")]
+use postgres::types::{IsNull, Type};
 use postgres::Connection;
 
 use super::{Composer, ComposerConfig, ComposerConnection};
@@ -14,6 +16,7 @@ use crate::types::SerdeValue;
 #[cfg(feature = "composer-serde")]
 use serde_value::Value;
 
+#[cfg(feature = "composer-serde")]
 use std::error::Error;
 
 impl<'a> ComposerConnection<'a> for Connection {

--- a/sql-composer/src/composer/rusqlite.rs
+++ b/sql-composer/src/composer/rusqlite.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, HashMap};
 
+#[cfg(feature = "composer-serde")]
 use rusqlite::types::ToSqlOutput;
 use rusqlite::{Connection, Statement};
 
@@ -15,6 +16,7 @@ use crate::types::SerdeValue;
 #[cfg(feature = "composer-serde")]
 use serde_value::Value;
 
+#[cfg(feature = "composer-serde")]
 use std::convert::From;
 
 impl<'a> ComposerConnection<'a> for Connection {
@@ -45,6 +47,7 @@ impl<'a> ComposerConnection<'a> for Connection {
     }
 }
 
+#[cfg(feature = "composer-serde")]
 impl ToSql for SerdeValue {
     fn to_sql(&self) -> rusqlite::Result<ToSqlOutput<'_>> {
         match &self.0 {

--- a/sql-composer/src/lib.rs
+++ b/sql-composer/src/lib.rs
@@ -31,7 +31,7 @@ extern crate nom_locate;
 #[macro_use]
 pub mod composer;
 
-#[cfg(feature = "dbd-postgres")]
+#[cfg(all(feature = "dbd-postgres", feature="composer-serde"))]
 #[macro_use]
 extern crate postgres;
 


### PR DESCRIPTION
Fix compiler warning when enabling any of the dbd-* features without composer-serde.

 ```bash
# at top level or from within sql-composer/sql-composer
cargo build
cargo build --all-features

# feature builds in sql-composer/sql-composer
#   these three were broken:
cargo build --features dbd-mysql
cargo build --features dbd-postgres
cargo build --features dbd-rusqlite
#   these already worked:
cargo build --features composer-serde
cargo build --features dbd-mysql\ composer-serde
cargo build --features dbd-postgres\ composer-serde
cargo build --features dbd-rusqlite\ composer-serde
```