### PR TITLE
Nom5 cleanup

### DIFF
--- a/sql-composer/src/composer.rs
+++ b/sql-composer/src/composer.rs
@@ -159,8 +159,8 @@ pub trait Composer: Sized {
             return self.compose_command(&sc, i, true);
         }
 
-        let mut pad = true;
-        let mut skip_this = false;
+        let mut pad;
+        let mut skip_this;
         let mut skip_next = false;
 
         for c in &sc.item.sql {

--- a/sql-composer/src/composer.rs
+++ b/sql-composer/src/composer.rs
@@ -130,6 +130,7 @@ macro_rules! bind_values(
 
 #[derive(Default)]
 pub struct ComposerConfig {
+    #[allow(dead_code)]
     start: usize,
 }
 

--- a/sql-composer/src/composer/direct.rs
+++ b/sql-composer/src/composer/direct.rs
@@ -10,6 +10,7 @@ pub struct Connection();
 
 #[derive(Default)]
 pub struct DirectComposer<'a> {
+    #[allow(dead_code)]
     config:           ComposerConfig,
     values:           BTreeMap<String, Vec<&'a dyn ToValue>>,
     root_mock_values: Vec<BTreeMap<String, &'a str>>,

--- a/sql-composer/src/composer/mysql.rs
+++ b/sql-composer/src/composer/mysql.rs
@@ -57,6 +57,7 @@ impl<'a> ComposerConnection<'a> for Pool {
 }
 
 pub struct MysqlComposer<'a> {
+    #[allow(dead_code)]
     config:           ComposerConfig,
     values:           BTreeMap<String, Vec<&'a dyn ToValue>>,
     root_mock_values: Vec<BTreeMap<String, &'a dyn ToValue>>,
@@ -235,6 +236,7 @@ mod tests {
         assert_eq!(found.data, person.data, "person's data");
     }
 
+    #[allow(dead_code)]
     fn parse(input: &str) -> ParsedItem<SqlComposition> {
         let (_remaining, stmt) = parse_template(Span::new(input.into()), None).unwrap();
 

--- a/sql-composer/src/composer/mysql.rs
+++ b/sql-composer/src/composer/mysql.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, HashMap};
 
 use mysql::{prelude::ToValue, Stmt};
 
+#[cfg(feature = "composer-serde")]
 use mysql::Value;
 
 use super::{Composer, ComposerConfig, ComposerConnection};
@@ -16,6 +17,7 @@ use serde_value::Value as SerdeValueEnum;
 
 use mysql::Pool;
 
+#[cfg(feature = "composer-serde")]
 impl Into<Value> for SerdeValue {
     fn into(self) -> Value {
         match self.0 {

--- a/sql-composer/src/composer/postgres.rs
+++ b/sql-composer/src/composer/postgres.rs
@@ -1,7 +1,9 @@
 use std::collections::{BTreeMap, HashMap};
 
 use postgres::stmt::Statement;
-use postgres::types::{IsNull, ToSql, Type};
+use postgres::types::ToSql;
+#[cfg(feature = "composer-serde")]
+use postgres::types::{IsNull, Type};
 use postgres::Connection;
 
 use super::{Composer, ComposerConfig, ComposerConnection};
@@ -14,6 +16,7 @@ use crate::types::SerdeValue;
 #[cfg(feature = "composer-serde")]
 use serde_value::Value;
 
+#[cfg(feature = "composer-serde")]
 use std::error::Error;
 
 impl<'a> ComposerConnection<'a> for Connection {

--- a/sql-composer/src/composer/postgres.rs
+++ b/sql-composer/src/composer/postgres.rs
@@ -32,6 +32,7 @@ impl<'a> ComposerConnection<'a> for Connection {
         mock_values: HashMap<SqlCompositionAlias, Vec<BTreeMap<String, Self::Value>>>,
     ) -> Result<(Self::Statement, Vec<Self::Value>), ()> {
         let c = PostgresComposer {
+            #[allow(dead_code)]
             config: PostgresComposer::config(),
             values,
             root_mock_values,
@@ -83,6 +84,7 @@ impl ToSql for SerdeValue {
 
 #[derive(Default)]
 pub struct PostgresComposer<'a> {
+    #[allow(dead_code)]
     config:           ComposerConfig,
     values:           BTreeMap<String, Vec<&'a dyn ToSql>>,
     root_mock_values: Vec<BTreeMap<String, &'a dyn ToSql>>,

--- a/sql-composer/src/composer/postgres.rs
+++ b/sql-composer/src/composer/postgres.rs
@@ -162,7 +162,7 @@ mod tests {
     use postgres::types::ToSql;
     use postgres::{Connection, TlsMode};
 
-    use std::collections::{BTreeMap, HashMap};
+    use std::collections::HashMap;
 
     use dotenv::dotenv;
     use std::env;

--- a/sql-composer/src/composer/rusqlite.rs
+++ b/sql-composer/src/composer/rusqlite.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, HashMap};
 
+#[cfg(feature = "composer-serde")]
 use rusqlite::types::ToSqlOutput;
 use rusqlite::{Connection, Statement};
 
@@ -15,6 +16,7 @@ use crate::types::SerdeValue;
 #[cfg(feature = "composer-serde")]
 use serde_value::Value;
 
+#[cfg(feature = "composer-serde")]
 use std::convert::From;
 
 impl<'a> ComposerConnection<'a> for Connection {
@@ -45,6 +47,7 @@ impl<'a> ComposerConnection<'a> for Connection {
     }
 }
 
+#[cfg(feature = "composer-serde")]
 impl ToSql for SerdeValue {
     fn to_sql(&self) -> rusqlite::Result<ToSqlOutput<'_>> {
         match &self.0 {

--- a/sql-composer/src/composer/rusqlite.rs
+++ b/sql-composer/src/composer/rusqlite.rs
@@ -876,7 +876,8 @@ mod tests {
 
         let stmt = SqlComposition::from_path_name("src/tests/values/simple.tql".into()).unwrap();
 
-        let composer = RusqliteComposer::new();
+        // TODO: why isn't composer used?
+        let _composer = RusqliteComposer::new();
 
         let bind_values = bind_values!(&dyn ToSql:
         "a" => [&"a_value"],

--- a/sql-composer/src/composer/rusqlite.rs
+++ b/sql-composer/src/composer/rusqlite.rs
@@ -32,6 +32,7 @@ impl<'a> ComposerConnection<'a> for Connection {
         mock_values: HashMap<SqlCompositionAlias, Vec<BTreeMap<String, Self::Value>>>,
     ) -> Result<(Self::Statement, Vec<Self::Value>), ()> {
         let c = RusqliteComposer {
+            #[allow(dead_code)]
             config: RusqliteComposer::config(),
             values,
             root_mock_values,
@@ -242,6 +243,8 @@ mod tests {
         assert_eq!(found.data, person.data, "person's data");
     }
 
+    // TODO: why does get_row_values exist?
+    #[allow(dead_code)]
     fn get_row_values(row: Row) -> Vec<String> {
         (0..4).fold(Vec::new(), |mut acc, i| {
             acc.push(row.get(i).unwrap());

--- a/sql-composer/src/error.rs
+++ b/sql-composer/src/error.rs
@@ -1,11 +1,3 @@
-use std::fmt;
-
-use crate::types::{Position, SqlComposition, SqlCompositionAlias};
-
-use nom_locate::LocatedSpan;
-
-type Span<'a> = LocatedSpan<&'a str>;
-
 error_chain! {
     errors {
         AliasConflict(t: String) {

--- a/sql-composer/src/lib.rs
+++ b/sql-composer/src/lib.rs
@@ -31,7 +31,7 @@ extern crate nom_locate;
 #[macro_use]
 pub mod composer;
 
-#[cfg(feature = "dbd-postgres")]
+#[cfg(all(feature = "dbd-postgres", feature="composer-serde"))]
 #[macro_use]
 extern crate postgres;
 

--- a/sql-composer/src/parser.rs
+++ b/sql-composer/src/parser.rs
@@ -12,8 +12,10 @@ use serde_value::Value;
 #[cfg(feature = "composer-serde")]
 use crate::types::SerdeValue;
 
+#[cfg(feature = "composer-serde")]
 use std::collections::BTreeMap;
 
+#[cfg(feature = "composer-serde")]
 use std::str::FromStr;
 
 named!(
@@ -737,7 +739,10 @@ mod tests {
     #[cfg(feature = "composer-serde")]
     use serde_value::Value;
 
-    use std::collections::{BTreeMap, HashMap};
+    #[cfg(feature = "composer-serde")]
+    use std::collections::BTreeMap;
+
+    use std::collections::HashMap;
     use std::path::{Path, PathBuf};
 
     use crate::tests::{build_parsed_binding_item, build_parsed_db_object,

--- a/sql-composer/src/parser.rs
+++ b/sql-composer/src/parser.rs
@@ -724,7 +724,7 @@ named!(
 
 #[cfg(test)]
 mod tests {
-    use super::{bindvar, bindvar_expecting, column_list, column_name, db_object, db_object_alias_sql,
+    use super::{bindvar, bindvar_expecting, column_list, db_object, db_object_alias_sql,
                 parse_composer_macro, parse_sql, parse_sql_end, parse_template};
 
     #[cfg(feature = "composer-serde")]
@@ -820,8 +820,8 @@ mod tests {
         shift_line: Option<u32>,
         shift_offset: Option<usize>,
     ) -> ParsedItem<SqlComposition> {
-        let shift_line = shift_line.unwrap_or(0);
-        let shift_offset = shift_offset.unwrap_or(0);
+        let _shift_line = shift_line.unwrap_or(0);
+        let _shift_offset = shift_offset.unwrap_or(0);
 
         let item = SqlComposition {
             position: Some(build_parsed_path_position(
@@ -1250,7 +1250,7 @@ mod tests {
 
         let expected_span = build_span(Some(1), Some(3), "tt");
 
-        let (leftover_span, span) = db_object_alias_sql(Span::new(input.into()))
+        let (_leftover_span, span) = db_object_alias_sql(Span::new(input.into()))
             .expect(&format!("expected Ok from parsing {}", input));
 
         assert_eq!(span, expected_span, "spans match");
@@ -1262,7 +1262,7 @@ mod tests {
 
         let expected_span = build_span(Some(1), Some(1), "AS");
 
-        let (leftover_span, span) = db_object_alias_sql(Span::new(input.into()))
+        let (_leftover_span, span) = db_object_alias_sql(Span::new(input.into()))
             .expect(&format!("expected Ok from parsing {}", input));
 
         assert_eq!(span, expected_span, "spans match");
@@ -1274,7 +1274,7 @@ mod tests {
 
         let expected_span = build_span(Some(1), Some(0), "tt");
 
-        let (leftover_span, span) = db_object_alias_sql(Span::new(input.into()))
+        let (_leftover_span, span) = db_object_alias_sql(Span::new(input.into()))
             .expect(&format!("expected Ok from parsing {}", input));
 
         assert_eq!(span, expected_span, "spans match");
@@ -1286,7 +1286,7 @@ mod tests {
 
         let expected_span = build_span(Some(1), Some(0), "tt");
 
-        let (leftover_span, span) = db_object_alias_sql(Span::new(input.into()))
+        let (_leftover_span, span) = db_object_alias_sql(Span::new(input.into()))
             .expect(&format!("expected Ok from parsing {}", input));
 
         assert_eq!(span, expected_span, "spans match");
@@ -1298,7 +1298,7 @@ mod tests {
 
         let expected_span = build_span(Some(1), Some(1), "tt");
 
-        let (leftover_span, span) = db_object_alias_sql(Span::new(input.into()))
+        let (_leftover_span, span) = db_object_alias_sql(Span::new(input.into()))
             .expect(&format!("expected Ok from parsing {}", input));
 
         assert_eq!(span, expected_span, "spans match");
@@ -1317,7 +1317,7 @@ mod tests {
 
         let expected_dbo_item = build_parsed_item(expected_dbo, None, Some(5), "t1");
 
-        let (span, (keyword_item, dbo_item)) = db_object(Span::new(input.into()))
+        let (span, (_keyword_item, dbo_item)) = db_object(Span::new(input.into()))
             .expect(&format!("expected Ok from parsing {}", input));
 
         assert_eq!(dbo_item, expected_dbo_item, "items match");
@@ -1337,7 +1337,7 @@ mod tests {
 
         let expected_dbo_item = build_parsed_item(expected_dbo, None, Some(5), "t1");
 
-        let (span, (keyword_item, dbo_item)) = db_object(Span::new(input.into()))
+        let (span, (_keyword_item, dbo_item)) = db_object(Span::new(input.into()))
             .expect(&format!("expected Ok from parsing {}", input));
 
         assert_eq!(dbo_item, expected_dbo_item, "DbObject items match");
@@ -1357,7 +1357,7 @@ mod tests {
 
         let expected_dbo_item = build_parsed_item(expected_dbo, None, Some(5), "t1");
 
-        let (span, (keyword_item, dbo_item)) = db_object(Span::new(input.into()))
+        let (span, (_keyword_item, dbo_item)) = db_object(Span::new(input.into()))
             .expect(&format!("expected Ok from parsing {}", input));
 
         assert_eq!(dbo_item, expected_dbo_item, "items match");

--- a/sql-composer/src/tests.rs
+++ b/sql-composer/src/tests.rs
@@ -24,6 +24,7 @@ pub fn build_parsed_item<T: Debug + Default + PartialEq + Clone>(
         .expect("expected Ok from ParsedItem::from_span in build_parsed_time()")
 }
 
+#[allow(dead_code)]
 pub fn build_parsed_string(
     item: &str,
     line: Option<u32>,
@@ -33,6 +34,7 @@ pub fn build_parsed_string(
     build_parsed_item(item.to_string(), line, offset, fragment)
 }
 
+#[allow(dead_code)]
 pub fn build_parsed_binding_item(
     name: &str,
     min: Option<u32>,
@@ -47,6 +49,7 @@ pub fn build_parsed_binding_item(
     build_parsed_item(binding, line, offset, fragment)
 }
 
+#[allow(dead_code)]
 pub fn build_parsed_sql_binding(
     name: &str,
     min: Option<u32>,
@@ -61,6 +64,7 @@ pub fn build_parsed_sql_binding(
     ))
 }
 
+#[allow(dead_code)]
 pub fn build_parsed_quoted_binding_item(
     name: &str,
     min: Option<u32>,
@@ -75,6 +79,7 @@ pub fn build_parsed_quoted_binding_item(
     build_parsed_item(quoted_binding, line, offset, fragment)
 }
 
+#[allow(dead_code)]
 pub fn build_parsed_sql_quoted_binding(
     name: &str,
     min: Option<u32>,
@@ -89,6 +94,7 @@ pub fn build_parsed_sql_quoted_binding(
     ))
 }
 
+#[allow(dead_code)]
 pub fn build_parsed_literal_item(
     item: &str,
     line: Option<u32>,
@@ -100,6 +106,7 @@ pub fn build_parsed_literal_item(
     build_parsed_item(literal, line, offset, fragment)
 }
 
+#[allow(dead_code)]
 pub fn build_parsed_sql_literal(
     item: &str,
     line: Option<u32>,
@@ -109,6 +116,7 @@ pub fn build_parsed_sql_literal(
     Sql::Literal(build_parsed_literal_item(item, line, offset, fragment))
 }
 
+#[allow(dead_code)]
 pub fn build_parsed_db_object_item(
     item: &str,
     alias: Option<String>,
@@ -121,6 +129,7 @@ pub fn build_parsed_db_object_item(
     build_parsed_item(object, line, offset, fragment)
 }
 
+#[allow(dead_code)]
 pub fn build_parsed_db_object(
     item: &str,
     alias: Option<String>,
@@ -133,6 +142,7 @@ pub fn build_parsed_db_object(
     ))
 }
 
+#[allow(dead_code)]
 pub fn build_parsed_keyword_item(
     item: &str,
     line: Option<u32>,
@@ -144,6 +154,7 @@ pub fn build_parsed_keyword_item(
     build_parsed_item(keyword, line, offset, fragment)
 }
 
+#[allow(dead_code)]
 pub fn build_parsed_sql_keyword(
     item: &str,
     line: Option<u32>,
@@ -164,6 +175,7 @@ pub fn build_parsed_ending_item(
     build_parsed_item(ending, line, offset, fragment)
 }
 
+#[allow(dead_code)]
 pub fn build_parsed_sql_ending(
     item: &str,
     line: Option<u32>,
@@ -173,6 +185,7 @@ pub fn build_parsed_sql_ending(
     Sql::Ending(build_parsed_ending_item(item, line, offset, fragment))
 }
 
+#[allow(dead_code)]
 pub fn build_parsed_path_position(
     path: PathBuf,
     line: u32,
@@ -191,6 +204,7 @@ pub fn build_parsed_path_position(
     Position::Parsed(span)
 }
 
+#[allow(dead_code)]
 pub fn build_span(line: Option<u32>, offset: Option<usize>, fragment: &str) -> Span {
     Span {
         line:     line.unwrap_or(1),

--- a/sql-composer/src/types.rs
+++ b/sql-composer/src/types.rs
@@ -21,7 +21,7 @@ use serde_value::Value;
 use std::fs::File;
 use std::io::prelude::*;
 
-struct Null();
+pub struct Null();
 
 #[derive(Debug, Hash, Eq, PartialEq, Clone)]
 pub enum Position {

--- a/sql-composer/src/types.rs
+++ b/sql-composer/src/types.rs
@@ -9,8 +9,6 @@ use std::fmt;
 use std::fmt::Debug;
 use std::path::{Path, PathBuf};
 
-use error_chain::bail;
-
 pub use nom_locate::LocatedSpan;
 
 pub type Span<'a> = LocatedSpan<& 'a str>;

--- a/sql-composer/src/types.rs
+++ b/sql-composer/src/types.rs
@@ -111,7 +111,7 @@ impl SqlCompositionAlias {
     }
 
     fn from_str(s: &str) -> Result<Self> {
-        let (is_name, is_path) = s.chars().fold((true, false), |mut acc, u| {
+        let (_is_name, _is_path) = s.chars().fold((true, false), |mut acc, u| {
             let c = u as char;
 
             match c {
@@ -302,7 +302,7 @@ impl SqlComposition {
     //TODO: error if path already set to Some(_)
     pub fn set_position(&mut self, new: Position) -> Result<()> {
         match &self.position {
-            Some(existing) => Err(ErrorKind::AliasConflict("bad posisition".into()).into()),
+            Some(_existing) => Err(ErrorKind::AliasConflict("bad posisition".into()).into()),
             None => {
                 self.position = Some(new);
                 Ok(())
@@ -340,7 +340,7 @@ impl SqlComposition {
     pub fn end(&mut self, value: &str, span: Span) -> Result<()> {
         //TODO: check if this has already ended
         match self.sql.last() {
-            Some(last) => self.push_sql(Sql::Ending(
+            Some(_last) => self.push_sql(Sql::Ending(
                 ParsedItem::from_span(
                     SqlEnding {
                         value: value.into(),

--- a/sql-composer/src/types/value.rs
+++ b/sql-composer/src/types/value.rs
@@ -51,6 +51,7 @@ impl ToValue for isize {
     }
 }
 
+#[allow(unused_macros)]
 macro_rules! from_optional_value(
     ($t: ty, $b: block) => (
         impl ToValue for $t {


### PR DESCRIPTION
* split dbd-* features from composer-serde
* Silence all warnings
  * the allow(dead_code) changes are all in one commit to make reverting easier.
  * is config in the struct for end-users?