### PR TITLE
Migrate from macro to functions: bind_value_text, bind_value_integer, bind_value_real

### DIFF
--- a/sql-composer/src/parser.rs
+++ b/sql-composer/src/parser.rs
@@ -523,12 +523,8 @@ pub fn bind_value_text(
         })(span)?;
     let (span, _) = one_of("'")(span)?;
     let (span, _) = check_bind_value_ending(span)?;
-    return Ok(
-        (
-            span,
-            SerdeValue(Value::String(found.fragment.to_string()))
-        )
-    )
+    Ok((span,
+        SerdeValue(Value::String(found.fragment.to_string()))))
 }
 
 #[cfg(feature = "composer-serde")]
@@ -536,13 +532,10 @@ pub fn bind_value_integer(
     span: Span,
     ) -> IResult<Span, SerdeValue> {
 
-    let (remaining, found) = digit1(span)?;
-    return Ok(
-        (
-            remaining,
-            SerdeValue(Value::I64(i64::from_str(&found.fragment).expect("unable to parse integer found by bind_value_integer")))
-        )
-    )
+    let (span, found) = digit1(span)?;
+    let (span, _) = check_bind_value_ending(span)?;
+    Ok((span,
+        SerdeValue(Value::I64(i64::from_str(&found.fragment).expect("unable to parse integer found by bind_value_integer")))))
 }
 
 #[cfg(feature = "composer-serde")]


### PR DESCRIPTION
Goal is to move al three bind_value_{text,integer,real} from
macros to functions, to allow usage of the complete (non-streaming)
versions of nom functions (e.g. take_while)

  * streaming parsers will return Incomplete error when a parser ends
    at a EOF boundary where the parser could optionally continue.
    e.g. "44" would be parsed as 44 by a complete int parser versus
    an Incomplete Error for a streaming parser.
  * macros are "soft deprecated" and now force streaming rather than
    complete implementations.