### PR TITLE
Feature/recursive macros

### DIFF
--- a/sql-composer-rusqlite/src/lib.rs
+++ b/sql-composer-rusqlite/src/lib.rs
@@ -674,6 +674,47 @@ mod tests {
     }
 
     #[test]
+    fn test_composed_union_command() -> EmptyResult {
+        let conn = setup_db();
+
+        let stmt = ":union(:count(col_1 of src/tests/values/double-include.tql), :count(col_4 of src/tests/values/include.tql), :count(col_2 of src/tests/values/double-include.tql));";
+
+        let expected_bound_sql = "SELECT COUNT(col_1) FROM (SELECT ?1 AS col_1, ?2 AS col_2, ?3 AS col_3, ?4 AS col_4 UNION ALL SELECT ?5 AS col_1, ?6 AS col_2, ?7 AS col_3, ?8 AS col_4 UNION ALL SELECT ?9 AS col_1, ?10 AS col_2, ?11 AS col_3, ?12 AS col_4) AS count_main UNION SELECT COUNT(col_4) FROM (SELECT ?13 AS col_1, ?14 AS col_2, ?15 AS col_3, ?16 AS col_4 UNION ALL SELECT ?17 AS col_1, ?18 AS col_2, ?19 AS col_3, ?20 AS col_4) AS count_main UNION SELECT COUNT(col_2) FROM (SELECT ?21 AS col_1, ?22 AS col_2, ?23 AS col_3, ?24 AS col_4 UNION ALL SELECT ?25 AS col_1, ?26 AS col_2, ?27 AS col_3, ?28 AS col_4 UNION ALL SELECT ?29 AS col_1, ?30 AS col_2, ?31 AS col_3, ?32 AS col_4) AS count_main;";
+
+        let mut composer = Composer::new();
+
+        composer.values = bind_values!(&dyn ToSql:
+                                       "a" => [&"a_value"],
+                                       "b" => [&"b_value"],
+                                       "c" => [&"c_value"],
+                                       "d" => [&"d_value"],
+                                       "e" => [&"e_value"],
+                                       "f" => [&"f_value"],
+                                       "col_1_values" => [&"d_value", &"a_value"],
+                                       "col_3_values" => [&"b_value", &"c_value"]
+        );
+
+        let bsc = composer.compose(stmt)?;
+
+        assert_eq!(bsc.sql(), expected_bound_sql, "preparable statements match");
+
+        let mut prep_stmt = conn.prepare(&bsc.sql())?;
+
+        let mut values: Vec<Vec<u8>> = vec![];
+
+        let rows = prep_stmt.query_map(bsc.values(), |row| Ok(vec![row.get(0)?]))?;
+
+        for row in rows {
+            values.push(row?);
+        }
+
+        let expected_values = vec![vec![2], vec![3]];
+
+        assert_eq!(values, expected_values, "exected values");
+        Ok(())
+    }
+
+    #[test]
     fn test_include_mock_multi_value_bind() -> EmptyResult {
         let conn = setup_db();
 

--- a/sql-composer/src/parser.rs
+++ b/sql-composer/src/parser.rs
@@ -1,4 +1,6 @@
-use crate::types::{ParsedItem, ParsedSpan, ParsedSql, ParsedSqlMacro, ParsedSqlStatement, Position, Span, Sql, SqlBinding, SqlCompositionAlias, SqlDbObject, SqlEnding, SqlKeyword, SqlLiteral, SqlMacro, SqlStatement, SqlMacroLiteral};
+use crate::types::{ParsedItem, ParsedSpan, ParsedSql, ParsedSqlMacro, ParsedSqlStatement,
+                   Position, Span, Sql, SqlBinding, SqlCompositionAlias, SqlDbObject, SqlEnding,
+                   SqlKeyword, SqlLiteral, SqlMacro, SqlMacroLiteral, SqlStatement};
 
 use crate::error::Result;
 
@@ -391,7 +393,7 @@ pub fn of_item_macro(span: Span) -> IResult<Span, ParsedItem<SqlCompositionAlias
     let (end_span, pmi) = composer_macro_item(span)?;
 
     let pma = ParsedItem {
-        item: SqlCompositionAlias::Macro(SqlMacroLiteral::new(&pmi.item)),
+        item:     SqlCompositionAlias::Macro(SqlMacroLiteral::new(&pmi.item)),
         position: pmi.position,
     };
 
@@ -617,13 +619,13 @@ mod tests {
 
     type EmptyResult = Result<()>;
 
+    use crate::parser::of_list;
     use crate::tests::{build_parsed_binding_item, build_parsed_db_object,
                        build_parsed_ending_item, build_parsed_item, build_parsed_path_position,
                        build_parsed_quoted_binding_item, build_parsed_sql_binding,
                        build_parsed_sql_ending, build_parsed_sql_keyword,
                        build_parsed_sql_literal, build_parsed_sql_quoted_binding,
                        build_parsed_string, build_span};
-    use crate::parser::of_list;
 
     fn simple_aliases(
         shift_line: Option<u32>,
@@ -1389,24 +1391,22 @@ mod tests {
         let pi = "src/tests/include-template.tql";
         let of = format!("{}, {}", ps, pi);
 
-        let (remainder, alias_items) = of_list(Span{ offset: 0, line: 1, fragment: &of, extra: () }).expect("list is parsable");
+        let (remainder, alias_items) = of_list(Span {
+            offset:   0,
+            line:     1,
+            fragment: &of,
+            extra:    (),
+        })
+        .expect("list is parsable");
 
         let expected_alias_items = vec![
             build_parsed_item(SqlCompositionAlias::from_path(ps), None, (1, 0), (1, 28)),
-            build_parsed_item(SqlCompositionAlias::from_path(pi), None, (1, 31), (1, 60))
+            build_parsed_item(SqlCompositionAlias::from_path(pi), None, (1, 31), (1, 60)),
         ];
 
-        assert_eq!(
-            alias_items,
-            expected_alias_items,
-            "alias list parsed"
-        );
+        assert_eq!(alias_items, expected_alias_items, "alias list parsed");
 
-        assert_eq!(
-            remainder.fragment,
-            "",
-            "nothing remaining"
-        )
+        assert_eq!(remainder.fragment, "", "nothing remaining")
     }
 
     #[test]
@@ -1415,7 +1415,13 @@ mod tests {
         let pi = "src/tests/include-template.tql";
         let of = format!(":compose({}), :compose({})", ps, pi);
 
-        let (remainder, alias_items) = of_list(Span{ offset: 0, line: 1, fragment: &of, extra: () }).expect("list is parsable");
+        let (remainder, alias_items) = of_list(Span {
+            offset:   0,
+            line:     1,
+            fragment: &of,
+            extra:    (),
+        })
+        .expect("list is parsable");
 
         let psm = SqlMacro {
             command: ParsedItem::new("compose".into(), None),
@@ -1431,20 +1437,12 @@ mod tests {
 
         let expected_alias_items = vec![
             build_parsed_item(SqlCompositionAlias::from_macro(psm), None, (1, 0), (1, 38)),
-            build_parsed_item(SqlCompositionAlias::from_macro(pim), None, (1, 41), (1, 80))
+            build_parsed_item(SqlCompositionAlias::from_macro(pim), None, (1, 41), (1, 80)),
         ];
 
-        assert_eq!(
-            alias_items,
-            expected_alias_items,
-            "alias list parsed"
-        );
+        assert_eq!(alias_items, expected_alias_items, "alias list parsed");
 
-        assert_eq!(
-            remainder.fragment,
-            "",
-            "nothing remaining"
-        )
+        assert_eq!(remainder.fragment, "", "nothing remaining")
     }
 }
 

--- a/sql-composer/src/types/mod.rs
+++ b/sql-composer/src/types/mod.rs
@@ -26,7 +26,7 @@ pub use position::Position;
 
 pub use span::{GeneratedSpan, LocatedSpan, ParsedSpan, Span};
 
-pub use sql::{Sql, SqlBinding, SqlDbObject, SqlEnding, SqlKeyword, SqlLiteral};
+pub use sql::{Sql, SqlBinding, SqlDbObject, SqlEnding, SqlKeyword, SqlLiteral, SqlMacroLiteral};
 
 pub use sql_composition::SqlComposition;
 pub use sql_composition_alias::SqlCompositionAlias;

--- a/sql-composer/src/types/sql.rs
+++ b/sql-composer/src/types/sql.rs
@@ -4,6 +4,7 @@ use std::fmt;
 
 use crate::error::Result;
 use crate::types::SqlMacro;
+use std::convert::TryFrom;
 
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub enum Sql {
@@ -115,6 +116,24 @@ impl fmt::Display for SqlKeyword {
 impl From<SqlKeyword> for Sql {
     fn from(value: SqlKeyword) -> Self {
         Sql::Keyword(value)
+    }
+}
+
+#[derive(Debug, Hash, Eq, PartialEq, Default, Clone)]
+pub struct SqlMacroLiteral(SqlLiteral);
+
+impl SqlMacroLiteral {
+    pub fn new(m: &SqlMacro) -> Self {
+        Self(SqlLiteral {
+            value: m.to_string(),
+            ..Default::default()
+        })
+    }
+}
+
+impl fmt::Display for SqlMacroLiteral {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", &self.0)
     }
 }
 

--- a/sql-composer/src/types/sql_composition_alias.rs
+++ b/sql-composer/src/types/sql_composition_alias.rs
@@ -7,12 +7,15 @@ use std::path::PathBuf;
 use std::str::FromStr;
 
 use crate::error::Error;
-use crate::types::{Span, SqlDbObject, SqlLiteral};
+use crate::types::{Span, SqlDbObject, SqlLiteral, SqlMacro};
+use crate::types::sql_macro::SqlMacroCommand;
+use crate::types::sql::SqlMacroLiteral;
 
 #[derive(Debug, Eq, Hash, PartialEq, Clone)]
 pub enum SqlCompositionAlias {
     Path(PathBuf),
     DbObject(SqlDbObject),
+    Macro(SqlMacroLiteral),
     SqlLiteral(SqlLiteral),
 }
 
@@ -46,6 +49,10 @@ impl SqlCompositionAlias {
         path.into().into()
     }
 
+    pub fn from_macro(m: SqlMacro) -> Self {
+        Self::Macro(SqlMacroLiteral::new(&m))
+    }
+
     /// Return an owned copy of the PathBuf for SqlCompositionAlias::Path types.
     pub fn path(&self) -> Option<PathBuf> {
         match self {
@@ -58,6 +65,7 @@ impl SqlCompositionAlias {
     pub fn read_raw_sql(&self) -> Result<String> {
         match self {
             SqlCompositionAlias::DbObject(dbo) => Ok(dbo.to_string()),
+            SqlCompositionAlias::Macro(ml) => Ok(ml.to_string()),
             SqlCompositionAlias::Path(path) => Ok(fs::read_to_string(&path)?),
             SqlCompositionAlias::SqlLiteral(s) => Ok(s.to_string()),
         }
@@ -143,8 +151,9 @@ impl FromStr for SqlCompositionAlias {
 impl fmt::Display for SqlCompositionAlias {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Self::Path(p) => write!(f, ", {}", p.to_string_lossy()),
-            Self::DbObject(dbo) => write!(f, ", {}", dbo),
+            Self::Path(p) => write!(f, "{}", p.to_string_lossy()),
+            Self::DbObject(dbo) => write!(f, "{}", dbo),
+            Self::Macro(ml) => write!(f, "{}", ml),
             Self::SqlLiteral(l) => write!(f, "{}", l),
         }
     }

--- a/sql-composer/src/types/sql_composition_alias.rs
+++ b/sql-composer/src/types/sql_composition_alias.rs
@@ -7,9 +7,9 @@ use std::path::PathBuf;
 use std::str::FromStr;
 
 use crate::error::Error;
-use crate::types::{Span, SqlDbObject, SqlLiteral, SqlMacro};
-use crate::types::sql_macro::SqlMacroCommand;
 use crate::types::sql::SqlMacroLiteral;
+use crate::types::sql_macro::SqlMacroCommand;
+use crate::types::{Span, SqlDbObject, SqlLiteral, SqlMacro};
 
 #[derive(Debug, Eq, Hash, PartialEq, Clone)]
 pub enum SqlCompositionAlias {

--- a/sql-composer/src/types/sql_macro.rs
+++ b/sql-composer/src/types/sql_macro.rs
@@ -96,18 +96,37 @@ impl Hash for SqlMacro {
 
 impl fmt::Display for SqlMacro {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        //write!(f, "{:?}\n\n", self);
         write!(f, ":{}(", self.command)?;
 
-        let mut c = 0;
+        let mut i = 0;
 
-        for col in &self.columns {
-            if c > 0 {
-                write!(f, ",")?;
+        if let Some(cols) = &self.columns {
+            for col in cols {
+                if i > 0 {
+                    write!(f, ",")?;
+                }
+
+                write!(f, "{}", col)?;
+
+                i += 1;
+            }
+        }
+
+        if i > 0 {
+            write!(f, " of ");
+        }
+
+        i = 0;
+
+        for o in &self.of {
+            if i > 0 {
+                write!(f, ", ");
             }
 
-            write!(f, "{:?}", col)?;
+            write!(f, "{}", o.item);
 
-            c += 1;
+            i += 1;
         }
 
         write!(f, ")")


### PR DESCRIPTION
This allows for macros to be used inside of macros where previously on a path could be used. This allows for calls such as `:union(:count(col_1 of src/tests/values/double-include.tql), :count(col_4 of src/tests/values/include.tql), :count(col_2 of src/tests/values/double-include.tql));`. Most of this was a parsing change since the composer now composes aliases as late as possible, so composition just worked.